### PR TITLE
Vectorized cell type estimation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,6 @@ Suggests:
     knitr,
     rmarkdown,
     testthat (>= 3.0.0)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.1
 VignetteBuilder: knitr
 Config/testthat/edition: 3

--- a/R/estimateCellTypeFromProjectionPerCluster.R
+++ b/R/estimateCellTypeFromProjectionPerCluster.R
@@ -2,6 +2,7 @@
 #'
 #' @param rca.obj RCA object.
 #' @param homogeneity a parameter indicating the homogeneity of the cluster. If the difference is below this threshold, the cell type will be set to unknown (default NULL).
+#' @param vec a parameter indicating vectorization in computing cell type estimates
 #' @return RCA object.
 #'
 #' @examples
@@ -13,26 +14,26 @@
 #' @export
 #'
 
-estimateCellTypeFromProjectionPerCluster <- function(rca.obj, homogeneity=NULL) {
+estimateCellTypeFromProjectionPerCluster <- function(rca.obj, homogeneity=NULL,vec=F) {
 
     # Assign data to tmp variables
     projection <- rca.obj$projection.data
     clusterColors <- rca.obj$clustering.out$dynamicColorsList[[1]]
 
-    # Vectorized
-    cellTypes <- as.list(rownames(projection)[max.col(Matrix::t(projection))])
-
-    # # Previous version
-    # # Returning the likeliest cell type of a cell irrespective of a confidence score
-    # cTIdfWU <- function(x){
-    #     return(base::names(x)[base::which(x == base::max(x))])
-    # }
-    # 
-    # # Determine the likeliest cell type for each cell.
-    # cellTypes <- base::list()
-    # for (i in base::c(1:base::dim(projection)[2])) {
-    #     cellTypes <- base::c(cellTypes,cTIdfWU(projection[,i]))
-    # }
+    if (vec) {
+        # Vectorized
+        cellTypes <- as.list(rownames(projection)[max.col(Matrix::t(projection))])
+    } else {
+        # Returning the likeliest cell type of a cell irrespective of a confidence score
+        cTIdfWU <- function(x){
+            return(base::names(x)[base::which(x == base::max(x))])
+        }
+        # Determine the likeliest cell type for each cell.
+        cellTypes <- base::list()
+        for (i in base::c(1:base::dim(projection)[2])) {
+            cellTypes <- base::c(cellTypes,cTIdfWU(projection[,i]))
+        }
+    }
 
     # Compute the cell type compositions of each cluster using per cell cell type predictions
     enrichmentAll <- base::c()

--- a/R/estimateCellTypeFromProjectionPerCluster.R
+++ b/R/estimateCellTypeFromProjectionPerCluster.R
@@ -19,17 +19,20 @@ estimateCellTypeFromProjectionPerCluster <- function(rca.obj, homogeneity=NULL) 
     projection <- rca.obj$projection.data
     clusterColors <- rca.obj$clustering.out$dynamicColorsList[[1]]
 
-    # Returning the likeliest cell type of a cell irrespective of a confidence score
-    cTIdfWU <- function(x){
-         return(base::names(x)[base::which(x == base::max(x))])
-    }
+    # Vectorized
+    cellTypes <- as.list(rownames(projection)[max.col(Matrix::t(projection))])
 
-    # Determine the likeliest cell type for each cell.
-    cellTypes <- base::list()
-    for (i in base::c(1:base::dim(projection)[2])) {
-          cellTypes <- base::c(cellTypes,cTIdfWU(projection[,i]))
-    }
-
+    # # Previous version
+    # # Returning the likeliest cell type of a cell irrespective of a confidence score
+    # cTIdfWU <- function(x){
+    #     return(base::names(x)[base::which(x == base::max(x))])
+    # }
+    # 
+    # # Determine the likeliest cell type for each cell.
+    # cellTypes <- base::list()
+    # for (i in base::c(1:base::dim(projection)[2])) {
+    #     cellTypes <- base::c(cellTypes,cTIdfWU(projection[,i]))
+    # }
 
     # Compute the cell type compositions of each cluster using per cell cell type predictions
     enrichmentAll <- base::c()

--- a/man/dataProjectWorker.Rd
+++ b/man/dataProjectWorker.Rd
@@ -27,7 +27,7 @@ dataProjectWorker(
 
 \item{scale}{True if the data should be scaled, False otherwise}
 
-\item{min.cell.number.expressing}{Minimum number of cells (0 percent -100 percent) expressing a gene such that it is considered in the projection step, default is 1 percent}
+\item{min.cell.number.expressing}{Minimum percent of cells (0 percent -100 percent) expressing a gene such that it is considered in the projection step, default is 1 percent}
 }
 \value{
 a projection matrix.

--- a/man/estimateCellTypeFromProjection.Rd
+++ b/man/estimateCellTypeFromProjection.Rd
@@ -8,7 +8,8 @@ estimateCellTypeFromProjection(
   rca.obj,
   confidence = NULL,
   ctRank = F,
-  cSCompute = F
+  cSCompute = F,
+  vec = F
 )
 }
 \arguments{
@@ -19,6 +20,8 @@ estimateCellTypeFromProjection(
 \item{ctRank}{parameter indicating whether a relative rank coloring for each cell type shall be computed (default FALSE).}
 
 \item{cSCompute}{parameter indicating wheter the confidence score should be computed for each cell (default FALSE).}
+
+\item{vec}{a parameter indicating vectorization in computing cell type estimates}
 }
 \value{
 RCA object.

--- a/man/estimateCellTypeFromProjectionPerCluster.Rd
+++ b/man/estimateCellTypeFromProjectionPerCluster.Rd
@@ -4,12 +4,14 @@
 \alias{estimateCellTypeFromProjectionPerCluster}
 \title{Estimate the most likely cell type from the projection to the reference panel}
 \usage{
-estimateCellTypeFromProjectionPerCluster(rca.obj, homogeneity = NULL)
+estimateCellTypeFromProjectionPerCluster(rca.obj, homogeneity = NULL, vec = F)
 }
 \arguments{
 \item{rca.obj}{RCA object.}
 
 \item{homogeneity}{a parameter indicating the homogeneity of the cluster. If the difference is below this threshold, the cell type will be set to unknown (default NULL).}
+
+\item{vec}{a parameter indicating vectorization in computing cell type estimates}
 }
 \value{
 RCA object.


### PR DESCRIPTION
### Summary

This pull request implements vectorized cell type estimation for the following functions:

- `RCAv2::estimateCellTypeFromProjection`
- `RCAv2::estimateCellTypeFromProjectionPerCluster`

The current implementation of these functions involves [appending to a list in a for loop](https://github.com/prabhakarlab/RCAv2/blob/e2974d2ec069aa1140e985c52fecf1ee14ea93e9/R/estimateCellTypeFromProjection.R#L64), which can incur high memory consumption and long runtimes. 

This PR vectorizes this process for cell type estimation without confidence values. For `RCAv2::estimateCellTypeFromProjection`, a parameter `vec` is introduced to indicate if vectorization is to be used. `vec=FALSE` defaults to the current implementation.
For `RCAv2::estimateCellTypeFromProjectionPerCluster`, the implementation has been changed to use vectorization by default.

With `vec=TRUE`, the function should run at least 200x faster and use at least 5x less RAM. 

### Tests

Below is a minimal reproducible example comparing `vec=FALSE` and `vec=TRUE` for equality, runtime and memory consumption.

Preprocessing:

<details>

```r
> library(RCAv2)
Loading required package: Matrix
>
> #' #### Fetch data 
> 
> destfile = '10xPBMCs.tar.gz'
> 
> download.file(
+     url = 'http://cf.10xgenomics.com/samples/cell-exp/3.0.2/5k_pbmc_protein_v3/5k_pbmc_protein_v3_raw_feature_bc_matrix.tar.gz',
+     destfile = destfile
+     )
trying URL 'http://cf.10xgenomics.com/samples/cell-exp/3.0.2/5k_pbmc_protein_v3/5k_pbmc_protein_v3_raw_feature_bc_matrix.tar.gz'
Content type 'application/x-tar' length 88537811 bytes (84.4 MB)
downloaded 84.4 MB
> 
> untar(destfile)
>
> PBMCs = createRCAObjectFrom10X('raw_feature_bc_matrix/')
> 
> PBMCs = RCAv2::dataFilter(
+     PBMCs,
+     nGene.thresholds = c(300,5000), 
+     nUMI.thresholds = c(400,30000),
+     percent.mito.thresholds = c(0.025,0.2),
+     min.cell.exp = 3,
+     plot=F
+ )
> 
> PBMCs = RCAv2::dataLogNormalise(PBMCs)
> 
> PBMCs = RCAv2::dataProject(
+     PBMCs,
+     method = "GlobalPanel",
+     corMeth = "pearson"
+ )
> 
> PBMCs = RCAv2::dataSClust(PBMCs, res = 0.15)
```

</details>

Benchmarking:

<details>

```r
> library(rbenchmark)
> library(peakRAM)
> 
> # Current impl.
> PBMcs1 = estimateCellTypeFromProjection(PBMCs, vec = FALSE)
> 
> # Vectorized impl.
> PBMCs2 = estimateCellTypeFromProjection(PBMCs, vec = TRUE)
> 
> # Check that outputs are equal
> all.equal(
+     PBMCs$cell.Type.Estimate,
+     PBMCs2$cell.Type.Estimate
+ )
[1] TRUE
> 
> # Check runtime
> rbenchmark::benchmark(
+     estimateCellTypeFromProjection(PBMCs, vec = FALSE),
+     estimateCellTypeFromProjection(PBMCs, vec = TRUE),
+     replications = 10,
+     columns = c('test', 'replications', 'elapsed', 'relative')
+ )
                                                test replications elapsed relative
1 estimateCellTypeFromProjection(PBMCs, vec = FALSE)           10   66.35  276.458
2  estimateCellTypeFromProjection(PBMCs, vec = TRUE)           10    0.24    1.000
> 
> # Check ram
> peakRAM::peakRAM(
+     estimateCellTypeFromProjection(PBMCs, vec = FALSE),
+     estimateCellTypeFromProjection(PBMCs, vec = TRUE)
+ )
                                    Function_Call Elapsed_Time_sec Total_RAM_Used_MiB Peak_RAM_Used_MiB
1 estimateCellTypeFromProjection(PBMCs,vec=FALSE)             6.47                  0             140.5
2  estimateCellTypeFromProjection(PBMCs,vec=TRUE)             0.03                  0              17.3
```

</details>

Session information:

<details>

```r
 sessionInfo()
R version 4.2.1 (2022-06-23 ucrt)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 10 x64 (build 19043)

Matrix products: default

locale:
[1] LC_COLLATE=English_Singapore.utf8  LC_CTYPE=English_Singapore.utf8    LC_MONETARY=English_Singapore.utf8
[4] LC_NUMERIC=C                       LC_TIME=English_Singapore.utf8    

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] peakRAM_1.0.2    rbenchmark_1.0.0 RCAv2_2.0.0      Matrix_1.4-1    

loaded via a namespace (and not attached):
  [1] utf8_1.2.2                  reticulate_1.25             tidyselect_1.1.2            RSQLite_2.2.17             
  [5] AnnotationDbi_1.58.0        htmlwidgets_1.5.4           grid_4.2.1                  docopt_0.7.1               
  [9] Rtsne_0.16                  devtools_2.4.5              munsell_0.5.0               preprocessCore_1.58.0      
 [13] codetools_0.2-18            ica_1.0-3                   interp_1.1-3                future_1.27.0              
 [17] miniUI_0.1.1.1              spatstat.random_2.2-0       colorspace_2.0-3            progressr_0.10.1           
 [21] Biobase_2.56.0              knitr_1.39                  ggalluvial_0.12.3           rstudioapi_0.13            
 [25] Seurat_4.1.1                stats4_4.2.1                ROCR_1.0-11                 tensor_1.5                 
 [29] listenv_0.8.0               MatrixGenerics_1.8.1        slam_0.1-50                 splancs_2.01-43            
 [33] GenomeInfoDbData_1.2.8      polyclip_1.10-0             bit64_4.0.5                 rhdf5_2.40.0               
 [37] parallelly_1.32.1           Matrix.utils_0.9.8          vctrs_0.4.1                 generics_0.1.3             
 [41] xfun_0.31                   fastcluster_1.2.3           R6_2.5.1                    doParallel_1.0.17          
 [45] GenomeInfoDb_1.32.4         clue_0.3-61                 pals_1.7                    bitops_1.0-7               
 [49] rhdf5filters_1.8.0          spatstat.utils_2.3-1        cachem_1.0.6                DelayedArray_0.22.0        
 [53] assertthat_0.2.1            promises_1.2.0.1            scales_1.2.1                nnet_7.3-17                
 [57] rgeos_0.5-9                 gtable_0.3.1                globals_0.15.1              goftest_1.2-3              
 [61] processx_3.7.0              WGCNA_1.71                  rlang_1.0.5                 GlobalOptions_0.1.2        
 [65] splines_4.2.1               lazyeval_0.2.2              impute_1.70.0               dichromat_2.0-0.1          
 [69] checkmate_2.1.0             spatstat.geom_2.4-0         reshape2_1.4.4              abind_1.4-5                
 [73] backports_1.4.1             httpuv_1.6.5                Hmisc_4.7-1                 qvalue_2.28.0              
 [77] tools_4.2.1                 usethis_2.1.6               sccore_1.0.2                ggplot2_3.3.6              
 [81] ellipsis_0.3.2              spatstat.core_2.4-4         RColorBrewer_1.1-3          BiocGenerics_0.42.0        
 [85] dynamicTreeCut_1.63-1       sessioninfo_1.2.2           ggridges_0.5.3              Rcpp_1.0.9                 
 [89] plyr_1.8.7                  base64enc_0.1-3             zlibbioc_1.42.0             purrr_0.3.4                
 [93] RCurl_1.98-1.8              ps_1.7.1                    prettyunits_1.1.1           rpart_4.1.16               
 [97] dbscan_1.1-10               deldir_1.0-6                pbapply_1.5-1               GetoptLong_1.0.5           
[101] cowplot_1.1.1               urlchecker_1.0.1            S4Vectors_0.34.0            zoo_1.8-10                 
[105] SeuratObject_4.1.0          SummarizedExperiment_1.26.1 grr_0.9.5                   ggrepel_0.9.1              
[109] cluster_2.1.3               fs_1.5.2                    magrittr_2.0.3              data.table_1.14.2          
[113] scattermore_0.8             circlize_0.4.15             lmtest_0.9-40               RANN_2.6.1                 
[117] fitdistrplus_1.1-8          matrixStats_0.62.0          pkgload_1.3.0               patchwork_1.1.1            
[121] mime_0.12                   xtable_1.8-4                jpeg_0.1-9                  mclust_5.4.10              
[125] sparsesvd_0.2-1             IRanges_2.30.1              gridExtra_2.3               shape_1.4.6                
[129] compiler_4.2.1              tibble_3.1.8                maps_3.4.0                  KernSmooth_2.23-20         
[133] crayon_1.5.2                htmltools_0.5.3             mgcv_1.8-40                 later_1.3.0                
[137] Formula_1.2-4               tidyr_1.2.1                 DBI_1.1.3                   ComplexHeatmap_2.12.1      
[141] MASS_7.3-57                 cli_3.4.0                   parallel_4.2.1              RcppHungarian_0.2          
[145] igraph_1.3.4                GenomicRanges_1.48.0        pkgconfig_2.0.3             foreign_0.8-82             
[149] sp_1.5-0                    plotly_4.10.0               spatstat.sparse_2.1-1       foreach_1.5.2              
[153] XVector_0.36.0              leidenAlg_1.0.3             stringr_1.4.1               callr_3.7.1                
[157] digest_0.6.29               sctransform_0.3.3           RcppAnnoy_0.0.19            Biostrings_2.64.1          
[161] spatstat.data_2.2-0         leiden_0.4.2                htmlTable_2.4.1             uwot_0.1.14                
[165] shiny_1.7.2                 rjson_0.2.21                nlme_3.1-157                lifecycle_1.0.2            
[169] Banksy_0.1.4                jsonlite_1.8.0              Rhdf5lib_1.18.2             mapproj_1.2.8              
[173] viridisLite_0.4.1           fansi_1.0.3                 pillar_1.8.1                lattice_0.20-45            
[177] KEGGREST_1.36.3             GO.db_3.15.0                fastmap_1.1.0               httr_1.4.4                 
[181] pkgbuild_1.3.1              survival_3.3-1              glue_1.6.2                  remotes_2.4.2              
[185] qlcMatrix_0.9.7             png_0.1-7                   iterators_1.0.14            bit_4.0.4                  
[189] stringi_1.7.8               profvis_0.3.7               blob_1.2.3                  latticeExtra_0.6-30        
[193] memoise_2.0.1               dplyr_1.0.10                irlba_2.3.5                 future.apply_1.9.0  
```
</details>